### PR TITLE
Update AOT to handle the new representation of Constructor Values

### DIFF
--- a/aot/aot.py
+++ b/aot/aot.py
@@ -225,7 +225,7 @@ class AoTCompiler(ExprFunctor):
 
     def visit_match(self, m):
         return CPPMatch(self.visit(m.data),
-                        [(c.lhs, self.visit(c.rhs)) for c in m.clause],
+                        [(c.lhs, self.visit(c.rhs)) for c in m.clauses],
                         m.checked_type)
 
     def visit_op(self, op):

--- a/aot/aot.py
+++ b/aot/aot.py
@@ -225,7 +225,7 @@ class AoTCompiler(ExprFunctor):
 
     def visit_match(self, m):
         return CPPMatch(self.visit(m.data),
-                        [(c.lhs, self.visit(c.rhs)) for c in m.clauses],
+                        [(c.lhs, self.visit(c.rhs)) for c in m.clause],
                         m.checked_type)
 
     def visit_op(self, op):

--- a/aot/convert.py
+++ b/aot/convert.py
@@ -16,7 +16,7 @@ def convert(a, ctx):
             a = (a.op, *a.args)
         elif isinstance(a, tuple):
             assert isinstance(a[0], relay.Constructor)
-            a = relay.backend.interpreter.ConstructorValue(a[0].tag, [convert(arg, ctx) for arg in a[1:]], a[0])
+            a = relay.backend.interpreter.ConstructorValue(a[0].tag, [convert(arg, ctx) for arg in a[1:]], a[0], [])
         elif isinstance(a, relay.backend.interpreter.TensorValue):
             return a
         elif isinstance(a, relay.backend.interpreter.ConstructorValue):

--- a/aot/convert.py
+++ b/aot/convert.py
@@ -16,7 +16,7 @@ def convert(a, ctx):
             a = (a.op, *a.args)
         elif isinstance(a, tuple):
             assert isinstance(a[0], relay.Constructor)
-            a = relay.backend.interpreter.ConstructorValue(a[0], [convert(arg, ctx) for arg in a[1:]], [])
+            a = relay.backend.interpreter.ConstructorValue(a[0].tag, [convert(arg, ctx) for arg in a[1:]], a[0])
         elif isinstance(a, relay.backend.interpreter.TensorValue):
             return a
         elif isinstance(a, relay.backend.interpreter.ConstructorValue):

--- a/aot/to_source.py
+++ b/aot/to_source.py
@@ -150,8 +150,8 @@ class ToSource:
                     ok_case += f"{next_label}:\n"
                 ok_case += f"goto {ok_label};"
                 return f"""
-                CHECK({data_name}->constructor->tag != -1);
-                if ({data_name}->constructor->tag == {pat.constructor.tag}) {{
+                CHECK({data_name}->tag != -1);
+                if ({data_name}->tag == {pat.constructor.tag}) {{
                   {ok_case}
                 }} else {{
                   goto {fail_label};
@@ -415,6 +415,7 @@ def mk_file(body, ctx):
       NodePtr<ConstructorValueNode> n = make_node<ConstructorValueNode>();
       NodePtr<ConstructorNode> con = make_node<ConstructorNode>();
       con->tag = tag;
+      n->tag = tag;
       n->constructor = Constructor(con);
       n->fields = fields;
       return ConstructorValue(n);

--- a/test/test_aot.py
+++ b/test/test_aot.py
@@ -1,6 +1,7 @@
 from tvm import relay
 from tvm.relay import var, Function, op, Module, GlobalVar, TypeVar, FuncType
 from tvm.relay.prelude import Prelude
+from tvm.relay.testing import add_nat_definitions
 import numpy as np
 import tvm
 import aot
@@ -122,6 +123,7 @@ def int_to_nat(p, i):
 def test_nat_3():
     mod = Module()
     p = Prelude(mod)
+    add_nat_definitions(p)
     cfunc = compile(Function([], p.s(p.s(p.s(p.z())))), mod)
     output = cfunc()
     assert nat_to_int(output) == 3
@@ -129,6 +131,7 @@ def test_nat_3():
 def test_nat_add():
     mod = Module()
     p = Prelude(mod)
+    add_nat_definitions(p)
     cfunc = compile(Function([], p.add(p.s(p.s(p.s(p.z()))), p.s(p.s(p.s(p.s(p.z())))))), mod)
     output = cfunc()
     assert nat_to_int(output) == 7
@@ -136,6 +139,7 @@ def test_nat_add():
 def test_add_convert():
     mod = Module()
     p = Prelude(mod)
+    add_nat_definitions(p)
     cfunc = compile(p.add, mod)
     output = cfunc(int_to_nat(p, 12), int_to_nat(p, 34))
     assert nat_to_int(output) == 46
@@ -171,6 +175,7 @@ def test_tuple():
 def test_compose():
     mod = Module()
     p = Prelude(mod)
+    add_nat_definitions(p)
     x = relay.Var('x')
     inc = GlobalVar('inc')
     mod[inc] = Function([x], p.s(x))


### PR DESCRIPTION
TVM PR https://github.com/dmlc/tvm/pull/3299 changed the representation of ConstructorValues. This PR updates the AoT compiler to follow that convention and also fixes some tests that were broken by changes to the Prelude