### PR TITLE
Use main instead of entry_func

### DIFF
--- a/aot/aot.py
+++ b/aot/aot.py
@@ -134,9 +134,9 @@ class AoTCompiler(ExprFunctor):
     def optimize(self, expr: Function) -> Function:
         opts = relay.transform.Sequential([relay.transform.FuseOps(),
                                            relay.transform.ToANormalForm()])
-        self.mod[self.mod.entry_func] = expr
-        opts(self.mod)
-        ret = self.mod[self.mod.entry_func]
+        self.mod['main'] = expr
+        self.mod = opts(self.mod)
+        ret = self.mod['main']
         fuse_check(ret, self.mod)
         return ret
 


### PR DESCRIPTION
A recent change to mainline TVM resulted in `entry_func` being removed from the module and its being replaced by a global variable named "main." This change fixes the AoT compiler to account for it.