### PR TITLE
Handle local recursion

### DIFF
--- a/aot/convert.py
+++ b/aot/convert.py
@@ -16,7 +16,7 @@ def convert(a, ctx):
             a = (a.op, *a.args)
         elif isinstance(a, tuple):
             assert isinstance(a[0], relay.Constructor)
-            a = relay.backend.interpreter.ConstructorValue(a[0].tag, [convert(arg, ctx) for arg in a[1:]], a[0], [])
+            a = relay.backend.interpreter.ConstructorValue(a[0].tag, [convert(arg, ctx) for arg in a[1:]], a[0])
         elif isinstance(a, relay.backend.interpreter.TensorValue):
             return a
         elif isinstance(a, relay.backend.interpreter.ConstructorValue):

--- a/aot/to_source.py
+++ b/aot/to_source.py
@@ -326,7 +326,7 @@ class ToSource:
 
         vb = self.visit(func.body)
         body = body + vb.stmt + f"""return {vb.expr};"""
-        expr = f"""FunctionValueNode::make([=](const std::vector<Value>& {vec}) {{
+        expr = f"""FunctionValueNode::make([&](const std::vector<Value>& {vec}) {{
                 {body}
             }});
             """

--- a/test/test_aot.py
+++ b/test/test_aot.py
@@ -157,7 +157,7 @@ def test_ref():
     body = relay.Let(iv, relay.RefRead(i), body)
     body = relay.Let(i, relay.RefCreate(relay.const(1, dtype='int32')), body)
     mod[three_with_ref] = relay.Function([], body)
-    cfunc = compile(three_with_ref, mod)
+    cfunc = compile(mod[three_with_ref], mod)
     output = cfunc()
     np.testing.assert_allclose(output.asnumpy(), np.array(3, dtype='int32'))
 
@@ -187,19 +187,19 @@ def test_compose():
     assert nat_to_int(cfunc(p.s(p.s(p.z())))) == 5
 
 
-#def test_recur_sum_local():
-#    mod = Module()
-#    x = var('x', dtype='int32', shape=())
-#    t = relay.TensorType(dtype='int32', shape=())
-#    sum = relay.Var('sum', type_annotation=relay.FuncType([t], t))
-#    c = relay.const(0)
-#    func = Function([x],
-#                    relay.If(op.less(x, c), c, x + sum(x - relay.const(1))),
-#                    t)
-#    body = relay.Let(sum, func, sum(relay.const(10)))
-#    cfunc = compile(mod, Function([], body))
-#    output = cfunc()
-#    np.testing.assert_allclose(output.asnumpy(), np.array(55, dtype='int32'))
+def test_recur_sum_local():
+   mod = Module()
+   x = var('x', dtype='int32', shape=())
+   t = relay.TensorType(dtype='int32', shape=())
+   sum = relay.Var('sum', type_annotation=relay.FuncType([t], t))
+   c = relay.const(0)
+   func = Function([x],
+                   relay.If(op.less(x, c), c, x + sum(x - relay.const(1))),
+                   t)
+   body = relay.Let(sum, func, sum(relay.const(10)))
+   cfunc = compile(Function([], body), mod)
+   output = cfunc()
+   np.testing.assert_allclose(output.asnumpy(), np.array(55, dtype='int32'))
 
 if __name__ == "__main__":
     test_identity()
@@ -217,3 +217,4 @@ if __name__ == "__main__":
     test_ref()
     test_tuple()
     test_compose()
+    test_recur_sum_local()


### PR DESCRIPTION
I encountered some bugs in which local recursion in Relay (as in `let f = fun(x, y) { ...; f(x', y'); ... }`) were leading to C++ compiler warnings and segfaults in AoT. It turned out that the C++ lambdas were not capturing their definition properly. I changed the generated lambdas to capture by reference. This also allowed a commented-out test to pass again.

Also included is an incorrect call to `Constructor` that had somehow not been caught before.

@MarisaKirisame please tell me if there was a reason the C++ lambdas did not capture by reference before.