### PR TITLE
Sanitize tensorflow variable names

### DIFF
--- a/aot/to_source.py
+++ b/aot/to_source.py
@@ -35,7 +35,7 @@ class ToSource:
         return name
 
     def sanitize(self, str):
-        return str.replace("-", "_")
+        return str.replace("-", "_").replace("/", "_")
 
     def fresh_local_name(self, var=None):
         if var is not None:


### PR DESCRIPTION
Converted tensorflow models have slashes in variable names depending on tensorflow variable scope. These cause compilation issues unless sanitized.