### PR TITLE
[bugfix] Update datatype check to use new TVM APIs

### DIFF
--- a/aot/to_source.py
+++ b/aot/to_source.py
@@ -405,7 +405,7 @@ def mk_file(body, ctx):
       cpu_ctx.device_type = kDLCPU;
       cpu_ctx.device_id = 0;
       NDArray cpu_array = nd.CopyTo(cpu_ctx);
-      CHECK_EQ(TVMType2Type(cpu_array->dtype), Bool());
+      CHECK_EQ(DataType(cpu_array->dtype), DataType::Bool());
       return reinterpret_cast<uint8_t*>(cpu_array->data)[0];
     }}
 


### PR DESCRIPTION
TVM PR [4560](https://github.com/apache/incubator-tvm/pull/4560) changed the APIs for checking datatypes of NDArrays, which broke a call in the AoT compiler. This PR updates that call to use the new APIs and ensures that the tests pass.

Please review @MarisaKirisame 