### PR TITLE
[api update] Use ObjectRef instead of Value, NDArrays instead of TensorValue

### DIFF
--- a/aot/convert.py
+++ b/aot/convert.py
@@ -10,15 +10,13 @@ def convert(a, ctx):
         elif isinstance(a, np.ndarray):
             a = tvm.nd.array(a, ctx)
         elif isinstance(a, tvm.ndarray.NDArray):
-            a = relay.backend.interpreter.TensorValue(a)
+            return a
         elif isinstance(a, relay.Call):
             assert isinstance(a.op, relay.Constructor)
             a = (a.op, *a.args)
         elif isinstance(a, tuple):
             assert isinstance(a[0], relay.Constructor)
             a = relay.backend.interpreter.ConstructorValue(a[0].tag, [convert(arg, ctx) for arg in a[1:]], a[0])
-        elif isinstance(a, relay.backend.interpreter.TensorValue):
-            return a
         elif isinstance(a, relay.backend.interpreter.ConstructorValue):
             return a
         else:


### PR DESCRIPTION
TVM PRs [4643](https://github.com/apache/incubator-tvm/pull/4643) and [4705](https://github.com/apache/incubator-tvm/pull/4705) changed the way values are handled in Relay, specifically by unifying the Relay `Value` class with TVM's `ObjectRef` and by replacing `TensorValue` altogether with `NDArray` (which now acts like a Relay `ObjectRef`). This PR updates the uses of these APIs in the AoT compiler.

Please review @MarisaKirisame 