### PR TITLE
[API update] Change reference to tvm.ndarray.NDArray to tvm.runtime.NDArray

### DIFF
--- a/aot/convert.py
+++ b/aot/convert.py
@@ -9,7 +9,7 @@ def convert(a, ctx):
             a = np.array(a, dtype='int32')
         elif isinstance(a, np.ndarray):
             a = tvm.nd.array(a, ctx)
-        elif isinstance(a, tvm.ndarray.NDArray):
+        elif isinstance(a, tvm.runtime.NDArray):
             return a
         elif isinstance(a, relay.Call):
             assert isinstance(a.op, relay.Constructor)


### PR DESCRIPTION
TVM PR [https://github.com/apache/incubator-tvm/pull/4818](4818) changed the Python module hierarchy for TVM's runtime data structures, including moving NDArrays to `tvm.runtime.NDArray`. This PR corrects a reference to NDArray in the AoT compiler.

Please review @MarisaKirisame 