### PR TITLE
[API update] Rename tvm.relay.Module to tvm.IRModule

### DIFF
--- a/aot/to_source.py
+++ b/aot/to_source.py
@@ -1,6 +1,6 @@
 from . import little_cpp
 from tvm import relay
-from tvm.relay import _module
+# from tvm.relay import _module
 from tvm.relay.prelude import Prelude
 
 class ExprWithStmt:

--- a/aot/to_source.py
+++ b/aot/to_source.py
@@ -1,6 +1,5 @@
 from . import little_cpp
 from tvm import relay
-# from tvm.relay import _module
 from tvm.relay.prelude import Prelude
 
 class ExprWithStmt:

--- a/test/test_aot.py
+++ b/test/test_aot.py
@@ -1,5 +1,6 @@
 from tvm import relay
-from tvm.relay import var, Function, op, Module, GlobalVar, TypeVar, FuncType
+from tvm import IRModule as Module
+from tvm.relay import var, Function, op, GlobalVar, TypeVar, FuncType
 from tvm.relay.prelude import Prelude
 from tvm.relay.testing import add_nat_definitions
 import numpy as np
@@ -161,7 +162,7 @@ def test_add_convert():
 
 
 def test_ref():
-    mod = relay.Module()
+    mod = Module()
     three_with_ref = relay.GlobalVar('three_with_ref')
     i = relay.Var('i')
     iv = relay.Var('iv')


### PR DESCRIPTION
TVM PR [4877](https://github.com/apache/incubator-tvm/pull/4877) renamed the Relay module to `tvm.IRModule`, among other things. This PR updates the references in the AoT compiler to the Relay module.