### PR TITLE
[API update] Change import for Relay function

### DIFF
--- a/aot/aot.py
+++ b/aot/aot.py
@@ -5,7 +5,8 @@ import subprocess
 import tempfile
 import tvm
 from tvm import relay, get_global_func, target, register_func
-from tvm.relay.expr import Expr, Function, Let, GlobalVar
+from tvm.relay.function import Function
+from tvm.relay.expr import Expr, Let, GlobalVar
 from tvm.relay.adt import Constructor
 from tvm.relay.expr_functor import ExprFunctor, ExprVisitor
 from tvm.relay.backend import compile_engine


### PR DESCRIPTION
TVM PR [5087](https://github.com/apache/incubator-tvm/pull/5087) moved the definition of the Python hook for Relay's `Function` node from `tvm.relay.expr` to `tvm.relay.function`. This PR updates the reference in the AoT compiler.