### PR TITLE
[API update] Use tvm.transform instead of relay.transform

### DIFF
--- a/aot/aot.py
+++ b/aot/aot.py
@@ -99,8 +99,8 @@ class AoTCompiler(ExprFunctor):
         self.bindings[-1].append((var, value))
 
     def optimize(self, expr: Function) -> Function:
-        opts = relay.transform.Sequential([relay.transform.FuseOps(),
-                                           relay.transform.ToANormalForm()])
+        opts = tvm.transform.Sequential([relay.transform.FuseOps(),
+                                         relay.transform.ToANormalForm()])
         self.mod['main'] = expr
         self.mod = opts(self.mod)
         ret = self.mod['main']


### PR DESCRIPTION
TVM PR [5337](https://github.com/apache/incubator-tvm/pull/5337) removed certain re-exports of `tvm.transform` so `relay.transform` no longer works for importing constructs like `Sequential`. This PR updates the use of that API.